### PR TITLE
Improve price badge visibility on room card

### DIFF
--- a/components/RoomCard.tsx
+++ b/components/RoomCard.tsx
@@ -106,8 +106,8 @@ export default function RoomCard({ room, resort, className = '' }: RoomCardProps
             priority
           />
           {/* Price Badge */}
-          <div className="absolute top-4 right-4 bg-zen-green text-white px-3 py-1 rounded-full text-sm font-semibold shadow-lg">
-            <div className="drop-shadow-sm">
+          <div className="absolute top-4 right-4 bg-zen-leaf text-white px-3 py-1 rounded-full text-sm font-semibold shadow-lg">
+            <div className="drop-shadow-md">
               <Price amount={room.price} showFrom={true} />
             </div>
           </div>


### PR DESCRIPTION
## Summary
- darken room price badge to `bg-zen-leaf`
- apply a stronger drop shadow to the price text

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840337d2e108327a6d0c45e059c42b6